### PR TITLE
fix: add missing header for DBL_EPSILON

### DIFF
--- a/src/Stage_3_PeakFinderSubFunctions.cpp
+++ b/src/Stage_3_PeakFinderSubFunctions.cpp
@@ -1,4 +1,6 @@
 #include <Rcpp.h>
+#include <cfloat>
+
 using namespace Rcpp;
 
 //####################################################


### PR DESCRIPTION
`cfloat` must be included before `DBL_EPSILON` can be used.